### PR TITLE
Fix Orleans testing package and implementation

### DIFF
--- a/src/Argus.Tests/Argus.Tests.csproj
+++ b/src/Argus.Tests/Argus.Tests.csproj
@@ -12,8 +12,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Orleans.TestKit" Version="8.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="8.0.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes Orleans testing setup:
- Replaces deprecated Orleans.TestKit with Orleans.TestingHost
- Updates test implementation to use TestCluster
- Adds Moq for mocking dependencies