### PR TITLE
Fix JWT and API versioning issues

### DIFF
--- a/src/Argus.Api/Versioning/ApiVersioningExtensions.cs
+++ b/src/Argus.Api/Versioning/ApiVersioningExtensions.cs
@@ -1,4 +1,7 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
 
 namespace Argus.Api.Versioning
 {
@@ -17,11 +20,8 @@ namespace Argus.Api.Versioning
                     new MediaTypeApiVersionReader("version"));
             });
 
-            services.AddVersionedApiExplorer(options =>
-            {
-                options.GroupNameFormat = "'v'VVV";
-                options.SubstituteApiVersionInUrl = true;
-            });
+            services.AddApiExplorer();
+            services.AddEndpointsApiExplorer();
 
             return services;
         }


### PR DESCRIPTION
This PR fixes several issues:

1. JWT Service Interface and Implementation:
   - Removed duplicate interface definition
   - Updated interface to match the implementation
   - Simplified token generation to just return the token string

2. API Versioning:
   - Added correct using statements
   - Updated API versioning configuration
   - Added proper API Explorer configuration

Changes made:
- Updated JwtTokenService.cs with correct interface
- Updated ApiVersioningExtensions.cs with proper configuration
- Removed ConfigureSwaggerOptions dependency
- Added proper endpoints explorer configuration

These changes should resolve the compilation errors related to JWT authentication and API versioning.